### PR TITLE
adding ability to load fixtures from bundle different then the one CMFixture resides in

### DIFF
--- a/CMFactory.podspec
+++ b/CMFactory.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
 
   s.xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => '"$(inherited)" "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 
-  s.dependency 'Mantle'
+  s.dependency 'Mantle', '~> 1.5.4'
 
 end

--- a/CMFactory.podspec
+++ b/CMFactory.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
 
   s.xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => '"$(inherited)" "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 
-  s.dependency 'Mantle', '~> 1.5.4'
+  s.dependency 'Mantle'
 
 end

--- a/CMFactory.podspec
+++ b/CMFactory.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'CMFactoryExampleTests/CMFactory'
 
-  s.xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => '"$(inherited)" "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 
   s.dependency 'Mantle', '~> 1.5.4'
 

--- a/CMFactory.podspec
+++ b/CMFactory.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'CMFactoryExampleTests/CMFactory'
 
-  s.xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 
   s.dependency 'Mantle', '~> 1.5.4'
 

--- a/CMFactoryExampleTests/CMFactory/CMFixture.h
+++ b/CMFactoryExampleTests/CMFactory/CMFixture.h
@@ -10,6 +10,7 @@
 
 @interface CMFixture : NSObject
 
++ (void)setBundleForLoadingFixtures:(NSBundle *)bundle;
 + (id) buildUsingMantleClass:(Class) objectClass fromFixture:(NSString *)fileName;
 + (id) buildUsingFixture:(NSString *)fileName;
 + (NSData *)dataFromFixtureNamed:(NSString *)fixtureName ofType:(NSString *)fixtureType;

--- a/CMFactoryExampleTests/CMFactory/CMFixture.m
+++ b/CMFactoryExampleTests/CMFactory/CMFixture.m
@@ -11,6 +11,18 @@
 
 @implementation CMFixture
 
+static NSBundle *bundle_ = nil;
+
++ (void)setBundleForLoadingFixtures:(NSBundle *)bundle
+{
+  bundle_ = bundle;
+}
+
++ (NSBundle *)getBundleForLoadingFixtures
+{
+  return bundle_ ?: [NSBundle bundleForClass:[self class]];
+}
+
 + (id)buildUsingMantleClass:(Class)objectClass fromFixture:(NSString *)fileName
 {
     [self checkIfClassIsSubclassOfMTlModel:objectClass];
@@ -139,7 +151,7 @@
 
 + (NSString *)pathOfFileNamed:(NSString *)fileName withExtension:(NSString *)extension
 {
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:fileName ofType:extension];
+    NSString *filePath = [[self getBundleForLoadingFixtures] pathForResource:fileName ofType:extension];
     return filePath;
 }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # CMFactory
 
+
+1. adapting project to use pods as frameworks:
+  - adding ‘use_frameworks!’ in pod files
+  - fixing #import statements across our source
+  - tree to work when dependencies are loaded as frameworks.
+  - fixing #import statements in a few pods so thatchy could be used as framework
+  - including source code of SCPStoreKitManager in our tree, since it
+  - 
 This project brings the idea of [FactoryGirl](https://github.com/thoughtbot/factory_girl) to iOS projects, and it loads fixtures and unmarshall them into a [Mantle](https://github.com/github/Mantle) class or NSDictionary class.
 
 ##Contact:


### PR DESCRIPTION
added CMFixture:setBundleForLoadingFixtures, which can be used to set
bundle in which CMFixture will look for fixtures. This is useful when
CMFixture is used as framework ( for example when using cocoapods with
'use_frameworks!'), since in that case the bundle from which fixtures are
loaded by default is the CMFixture framework bundle.
